### PR TITLE
chore(deps): bump https://github.com/vicky-socs/test-python-jenkinsx.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[vicky-socs/test-python-jenkinsx](https://github.com/vicky-socs/test-python-jenkinsx.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: vicky-socs
+  repo: test-python-jenkinsx
+  url: https://github.com/vicky-socs/test-python-jenkinsx.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
+++ b/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: vicky-socs
+    provider: github
+    repository: test-python-jenkinsx
+  name: vicky-socs-test-python-jenkinsx
+spec:
+  description: Imported application for vicky-socs/test-python-jenkinsx
+  httpCloneURL: https://github.com/vicky-socs/test-python-jenkinsx.git
+  org: vicky-socs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: test-python-jenkinsx
+  scheduler:
+    kind: ""
+    name: default-scheduler
+  url: git@github.com:vicky-socs/test-python-jenkinsx.git


### PR DESCRIPTION
Update [vicky-socs/test-python-jenkinsx](https://github.com/vicky-socs/test-python-jenkinsx.git) 

Command run was `jx import --scheduler=default-scheduler`