### PR TITLE
chore(deps): bump https://github.com/vicky-socs/test-python-jenkinsx.git 

### DIFF
--- a/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
+++ b/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
@@ -1,11 +1,14 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
+    jenkins.io/last-build-number-for-pr-1: "1"
   creationTimestamp: null
   labels:
     jenkins.io/chart-release: repos
     jenkins.io/namespace: jx
-    jenkins.io/version: "1"
+    jenkins.io/version: "2"
     owner: vicky-socs
     provider: github
     repository: test-python-jenkinsx


### PR DESCRIPTION
Update [vicky-socs/test-python-jenkinsx](https://github.com/vicky-socs/test-python-jenkinsx.git) 

Command run was `jx import --scheduler default-scheduler`