### PR TITLE
chore(deps): bump https://github.com/vicky-socs/test-python-jenkinsx.git 

### DIFF
--- a/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
+++ b/repositories/templates/vicky-socs-test-python-jenkinsx-sr.yaml
@@ -2,14 +2,14 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "2"
+    jenkins.io/last-build-number-for-master: "3"
     jenkins.io/last-build-number-for-pr-1: "1"
     jenkins.io/last-build-number-for-staging: "1"
   creationTimestamp: null
   labels:
     jenkins.io/chart-release: repos
     jenkins.io/namespace: jx
-    jenkins.io/version: "4"
+    jenkins.io/version: "5"
     owner: vicky-socs
     provider: github
     repository: test-python-jenkinsx
@@ -24,5 +24,5 @@ spec:
   repo: test-python-jenkinsx
   scheduler:
     kind: ""
-    name: default-scheduler
+    name: zyla-scheduler
   url: git@github.com:vicky-socs/test-python-jenkinsx.git


### PR DESCRIPTION
Update [vicky-socs/test-python-jenkinsx](https://github.com/vicky-socs/test-python-jenkinsx.git) 

Command run was `jx import --scheduler=zyla-scheduler`